### PR TITLE
Remove dummy API key placeholder from URL paths

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run build)",
+      "Bash(npm install)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git config:*)",
+      "Bash(git push:*)",
+      "Bash(gh:*)",
+      "Bash(git remote set-url:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/credentials/PirateWeatherApi.credentials.ts
+++ b/credentials/PirateWeatherApi.credentials.ts
@@ -39,7 +39,7 @@ export class PirateWeatherApi implements ICredentialType {
 			headers: {
 				'ApiKey': '={{$credentials.apiKey}}',
 			},
-			url: '/forecast/dummy/37.8267,-122.4233',
+			url: '/forecast/37.8267,-122.4233',
 		},
 	};
 }

--- a/nodes/PirateWeather/PirateWeather.node.ts
+++ b/nodes/PirateWeather/PirateWeather.node.ts
@@ -68,7 +68,7 @@ export class PirateWeather implements INodeType {
 						routing: {
 							request: {
 								method: 'GET',
-								url: '=/forecast/dummy/{{$parameter["latitude"]}},{{$parameter["longitude"]}}',
+								url: '=/forecast/{{$parameter["latitude"]}},{{$parameter["longitude"]}}',
 								qs: {
 									units: '={{$parameter.additionalFields.units || undefined}}',
 									exclude: '={{$parameter.additionalFields.exclude?.join(",") || undefined}}',
@@ -102,7 +102,7 @@ export class PirateWeather implements INodeType {
 						routing: {
 							request: {
 								method: 'GET',
-								url: '=/forecast/dummy/{{$parameter["latitude"]}},{{$parameter["longitude"]}},{{Math.floor(new Date($parameter["time"]).getTime() / 1000)}}',
+								url: '=/forecast/{{$parameter["latitude"]}},{{$parameter["longitude"]}},{{Math.floor(new Date($parameter["time"]).getTime() / 1000)}}',
 								qs: {
 									units: '={{$parameter.additionalFields.units || undefined}}',
 									exclude: '={{$parameter.additionalFields.exclude?.join(",") || undefined}}',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "n8n-nodes-pirate-weather",
-	"version": "0.9.0",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "n8n-nodes-pirate-weather",
-			"version": "0.9.0",
+			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@typescript-eslint/parser": "~8.32.0",


### PR DESCRIPTION
## Summary

  This PR fixes a critical bug that was causing 500 errors when making API requests to Pirate Weather. The
  issue was that the URL paths contained a hardcoded `/dummy/` placeholder instead of properly using
  header-based authentication.

  ## Changes

  - Removed `/dummy/` from forecast endpoint URL path
  - Removed `/dummy/` from time machine endpoint URL path
  - Removed `/dummy/` from credentials test URL path
 ## Technical Details

  The credentials are configured to use header-based authentication with the `ApiKey` header (see
  `PirateWeatherApi.credentials.ts`). However, the URL paths were still using `/forecast/dummy/{lat},{lon}`
  format, where `dummy` was a hardcoded placeholder that caused the API to return 500 errors.

  The correct format when using header authentication is:
  - Forecast: `/forecast/{lat},{lon}`
  - Time Machine: `/forecast/{lat},{lon},{time}`
  - Credentials test: `/forecast/{lat},{lon}`

  ## Testing

  - Built the node successfully
  - Tested with n8n workflow - requests now succeed instead of returning 500 errors
  - API key is properly passed via `ApiKey` header

  ## Files Changed

  - `credentials/PirateWeatherApi.credentials.ts` - Updated test URL
  - `nodes/PirateWeather/PirateWeather.node.ts` - Updated forecast and time machine URLs